### PR TITLE
Implement graceful shutdown on the http server

### DIFF
--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -46,12 +46,15 @@ async fn main() {
     let app = api::build_router(query_pool.clone());
     let listener = tokio::net::TcpListener::bind(&bind_addr).await.unwrap();
 
-    tokio::spawn(async move {
-        axum::serve(listener, app)
-            .await
-            .expect("Failed to start HTTP server");
-    });
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async {
+            tokio::signal::ctrl_c()
+                .await
+                .expect("Failed to install Ctrl+C handler");
+            info!("Ctrl+C received. Gracefully shutting down the HTTP server (waiting for active requests to finish)...");
+        })
+        .await
+        .expect("Failed to start HTTP server");
 
-    tokio::signal::ctrl_c().await.unwrap();
     info!("Shutting down Seed Node...");
 }


### PR DESCRIPTION
Implemented `with_graceful_shutdown` in the `query` binary. The Axum server now intercepts `Ctrl+C` and waits for active HTTP requests to finish before terminating the Tokio runtime.